### PR TITLE
Change default Line-us name

### DIFF
--- a/Line_Us_SVG.pde
+++ b/Line_Us_SVG.pde
@@ -18,7 +18,7 @@ boolean connected;
 boolean hide = false;
 float resolution = 5;
 
-String lineus_adress = "lineus.local"; //"192.168.4.1";
+String lineus_adress = "line-us.local"; //"192.168.4.1";
 
 LineUs myLineUs;
 
@@ -161,7 +161,7 @@ void keyPressed()
   } 
   else if (key == 'a')
   {
-      lineus_adress = JOptionPane.showInputDialog("LineUs Address (lineus.local, 192.168.4.1, ...):");
+      lineus_adress = JOptionPane.showInputDialog("LineUs Address (line-us.local, 192.168.4.1, ...):");
   }
   else if (key == 'h')
   {


### PR DESCRIPTION
Just a minor change - the default Line-us name is `line-us.local` rather than `lineus.local`. Would you ba able to merge and create a new release with the installable versions? The app is proving to be quite popular and this comes up as an issue quite a lot!