### PR TITLE
Processing3 Compatibility

### DIFF
--- a/Line_Us_SVG.pde
+++ b/Line_Us_SVG.pde
@@ -37,7 +37,7 @@ int lw = 1775 - 650;
 int lh = 2000;
 
 void setup() {
-  size(lw/2, lh/2);
+  surface.setSize(lw/2, lh/2);
   smooth();
 
   RG.init(this);


### PR DESCRIPTION
size() no longer supports the use of variables as of Processing3. surface.setSize() does though.